### PR TITLE
Fixed the Order of the messages

### DIFF
--- a/src/stores/MessageStore.tsx
+++ b/src/stores/MessageStore.tsx
@@ -49,7 +49,7 @@ export class MessageStore {
             secret: reciver.secret,
             reciverAddress: reciver.address,
             message: messageText,
-            time: new Date().getTime(),
+            time: parseInt(new Date().getTime().toString().substr(0,10), 10),
             status: MessageStatus.Sending,
             toITextMessage: Message.prototype.toITextMessage // bad typescript hack
         }

--- a/src/stores/MessageStore.tsx
+++ b/src/stores/MessageStore.tsx
@@ -76,7 +76,7 @@ export class MessageStore {
 
     private addMessages = (messages: ITextMessage[]) => {
         messages.forEach(m => this.messages.push(toMessage(m)))
-        this.messages = this.messages.slice().sort((a, b) => a.time > b.time ? 1 : -1); // sort messages by time
+        this.messages = this.messages.slice().sort((a, b) => a.time - b.time); // sort messages by time
     }
 
     


### PR DESCRIPTION
The timestamp stored on the tangle of iota is 10 digits.
The timestamp that we get from Date().getTime() is 13 digits.

This means that when we send a new message, this message gets added in the message store with 13 digits instead of 10 digits and this causes the sorting problems.
By truncating the newly generated timestamp to 10 digits solves this problem.