### PR TITLE
Added workaround for logout to clear the settings

### DIFF
--- a/src/components/TitleBaar.tsx
+++ b/src/components/TitleBaar.tsx
@@ -136,9 +136,9 @@ class TitleBaarComponent extends React.Component<IPorps, IState> {
     };
     
     private logout = () => {
-        window.sessionStorage.clear()
-        window.localStorage.clear()
-        settingStore.seed = ''
+        window.sessionStorage.clear();
+        window.localStorage.clear();
+        settingStore.dispose();
     }
 }
 

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -95,6 +95,9 @@ class LoginComponent extends React.Component<IPorps, IState> {
 
   public render() {
     const {classes} = this.props;
+    if (settingStore.Iota !== undefined) {
+      location.reload(true);
+    }
     if (settingStore.seed !== '') {
       return <Redirect to={{pathname: '/chat'}}/>;
     }

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -95,9 +95,6 @@ class LoginComponent extends React.Component<IPorps, IState> {
 
   public render() {
     const {classes} = this.props;
-    if (settingStore.Iota !== undefined) {
-      location.reload(true);
-    }
     if (settingStore.seed !== '') {
       return <Redirect to={{pathname: '/chat'}}/>;
     }

--- a/src/services/iotaService/IotaService.tsx
+++ b/src/services/iotaService/IotaService.tsx
@@ -5,6 +5,7 @@ import { IBaseMessage, MessageMethod, ITextMessage, IContactResponse, Permission
 import { getRandomSeed, arrayDiff } from '../../utils';
 import { EventHandler } from '../../utils/EventHandler';
 import { IICERequest } from './interfaces/IICERequest';
+import Timer = NodeJS.Timer;
 
 
 export class Iota extends EventHandler {
@@ -19,6 +20,7 @@ export class Iota extends EventHandler {
     private loadedHashes: string[];
     private isCallRunning: boolean = false;
     private isBootStrapped: boolean = false;
+    private checkForNewMessageTimer: Timer;
 
     constructor(provider: string, seed: string) {
         super();
@@ -81,6 +83,10 @@ export class Iota extends EventHandler {
         }
     }
 
+    public dispose() {
+        clearInterval(this.checkForNewMessageTimer);
+    }
+
     // #### Internale Methods ####
     public async bootstrapMessenger() {
         const accountData: AccountData = await this.api.getAccountData(this.seed)
@@ -93,7 +99,7 @@ export class Iota extends EventHandler {
             this.ownAddress = await this.api.getNewAddress(this.seed)
         }
         this.isBootStrapped = true;
-        setInterval(async () => {
+        this.checkForNewMessageTimer = setInterval(async () => {
             await this.checkForNewMessages();
           }, 5000);
     }

--- a/src/stores/ContactStore.tsx
+++ b/src/stores/ContactStore.tsx
@@ -163,6 +163,11 @@ export class ContactStore {
             
         })
     }
+
+    public dispose() {
+        this.contacts = {};
+        this._currentContact = '';
+    }
 }
 
 

--- a/src/stores/MessageStore.tsx
+++ b/src/stores/MessageStore.tsx
@@ -76,6 +76,10 @@ export class MessageStore {
         this.messages.push(messages)
     }
 
+    public dispose() {
+        this.messages = [];
+    }
+
     private addMessages = (messages: ITextMessage[]) => {
         messages.forEach(m => this.messages.push(toMessage(m)))
         this.messages = this.messages.slice().sort((a, b) => a.time - b.time); // sort messages by time

--- a/src/stores/SettingStore.tsx
+++ b/src/stores/SettingStore.tsx
@@ -54,6 +54,15 @@ export class SettingStore {
         this._seed = seed;
     }
 
+    public dispose() {
+        this._myName = undefined;
+        this._seed = '';
+        this.myAddress = undefined;
+        this.Iota.dispose();
+        messageStore.dispose();
+        contactStore.dispose();
+    }
+
     public async setupMessanger() {
         this.Iota = new Iota(this.host + ':' + this.port, this.seed);
         messageStore.subscribeForMessages();


### PR DESCRIPTION
When an user logs out the Contactstore doesn't get cleared up and the IotaService still runs in the background Fetching the messages from the tangle.
There is no easy way to shutdown properly the IotaService, so I decided to apply a workaround, that when the login page is loaded, it checks if the IotaService exists. If it exists it reloads the webpage.
 